### PR TITLE
Fix AWS credential expiration in ECS by implementing periodic refresh

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,32 +1,30 @@
 #!/bin/bash
 
-#
-# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
-#
-# Licensed under the Amazon Software License (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-#   http://aws.amazon.com/asl/
-#
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language governing
-# permissions and limitations under the License.
-#
+# Function to refresh credentials
+refresh_credentials() {
+  # Get credentials from ECS container metadata endpoint
+  CREDS=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
+  
+  # Extract credentials and set as environment variables
+  export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
+  export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
+  export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
+  export AWS_REGION=$(curl -s 169.254.169.254/latest/meta-data/placement/region || echo "us-east-1")
+  
+  echo "AWS credentials refreshed at $(date)"
+}
 
+# Initial credential fetch
+refresh_credentials
 
-# Get credentials from ECS container metadata endpoint
-CREDS=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
-
-# Extract credentials and set as environment variables
-export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
-export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
-export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
-export AWS_REGION=$(curl -s 169.254.169.254/latest/meta-data/placement/region || echo "us-east-1")
-
-# Print confirmation (remove in production)
-echo "AWS credentials set from task role"
+# Start credential refresh in background
+(
+  while true; do
+    # Sleep for 30 minutes (1800 seconds)
+    sleep 1800
+    refresh_credentials
+  done
+) &
 
 # Execute the main application
 exec "$@"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+#
+# Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#   http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
 # Function to refresh credentials
 refresh_credentials() {
   # Get credentials from ECS container metadata endpoint


### PR DESCRIPTION
Prevents ExpiredTokenException after 6-12 hours by:
- Adding credential timestamp tracking
- Reinitializing Bedrock client every 25 minutes
- Ensuring fresh credentials for new connection streams

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
